### PR TITLE
correct embed_dim for PE-Core-B16-224; add einops to the dependency list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ training = [
     'transformers[sentencepiece]',
     'timm>=1.0.10',
     'fsspec',
+    'einops'
 ]
 test = [
     'pytest-split',

--- a/src/open_clip/model_configs/PE-Core-B16-224.json
+++ b/src/open_clip/model_configs/PE-Core-B16-224.json
@@ -1,5 +1,5 @@
 {
-    "embed_dim": 768,
+    "embed_dim": 1024,
     "quick_gelu": false,
     "vision_cfg": {
         "image_size": 224,


### PR DESCRIPTION
Hi @berniebear, thank you for making this repository available! It has been very helpful for experimenting with PE training while integration with HuggingFace timm and open_clip is in progress.

While working with **PE-Core-B16-224**, I noticed that the embed_dim was set to 768, which caused errors when loading the model checkpoint. After reviewing both the paper and the repository, I updated this value to 1024 to match the correct configuration. Additionally, I added a missing dependency to ensure smoother installation.

Could you please review and consider merging these changes?

Thank you again for the excellent work and for your support.